### PR TITLE
Change accounts package to okgrow:accounts-ui-react

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -17,8 +17,7 @@ standard-minifier-js    # JS minifier run for production mode
 es5-shim                # ECMAScript 5 compatibility for older browsers.
 ecmascript              # Enable ECMAScript2015+ syntax in app code
 
-std:accounts-ui
-std:accounts-basic
 accounts-password
 react-meteor-data
 apollo
+okgrow:accounts-ui-react

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -57,7 +57,7 @@ mongo-id@1.0.5
 npm-bcrypt@0.8.7
 npm-mongo@1.4.44_1
 observe-sequence@1.0.12
-okgrow:accounts-ui-react@0.6.2
+okgrow:accounts-ui-react@0.7.1
 ordered-dict@1.0.8
 promise@0.7.2_1
 random@1.0.10

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,5 +1,7 @@
 accounts-base@1.2.8
 accounts-password@1.1.11
+accounts-ui@1.1.9
+accounts-ui-unstyled@1.1.12
 allow-deny@1.0.5
 apollo@0.0.3
 autoupdate@1.2.10
@@ -15,7 +17,6 @@ caching-compiler@1.0.5_1
 caching-html-compiler@1.0.6
 callback-hook@1.0.9
 check@1.2.3
-coffeescript@1.1.2_1
 ddp@1.2.5
 ddp-client@1.2.8_1
 ddp-common@1.2.6
@@ -29,7 +30,6 @@ ejson@1.0.12
 email@1.0.14_1
 es5-shim@4.5.12_1
 fastclick@1.0.12
-fourseven:scss@3.4.3
 geojson-utils@1.0.9
 hot-code-push@1.0.4
 html-tools@1.0.10
@@ -37,7 +37,9 @@ htmljs@1.0.10
 http@1.1.7
 id-map@1.0.8
 jquery@1.11.9
+jsx@0.2.4
 launch-screen@1.0.12
+less@2.6.3_1
 livedata@1.0.18
 localstorage@1.0.11
 logging@1.0.13_1
@@ -55,6 +57,7 @@ mongo-id@1.0.5
 npm-bcrypt@0.8.7
 npm-mongo@1.4.44_1
 observe-sequence@1.0.12
+okgrow:accounts-ui-react@0.6.2
 ordered-dict@1.0.8
 promise@0.7.2_1
 random@1.0.10
@@ -68,16 +71,14 @@ routepolicy@1.0.11
 service-configuration@1.0.10
 session@1.1.6
 sha@1.0.8
-softwarerero:accounts-t9n@1.3.4
 spacebars@1.0.12
 spacebars-compiler@1.0.12
 srp@1.0.9
 standard-minifier-css@1.0.7_1
 standard-minifier-js@1.0.7_1
-std:accounts-basic@1.1.12
-std:accounts-ui@1.2.6
 templating@1.1.12_1
 templating-tools@1.0.4
+thereactivestack:blazetoreact@1.0.2
 tmeasday:check-npm-versions@0.3.1
 tracker@1.0.14
 ui@1.0.11

--- a/client/main.css
+++ b/client/main.css
@@ -1,1 +1,4 @@
 /* CSS declarations go here */
+#login-dropdown-list {
+  position: relative;
+}

--- a/client/main.css
+++ b/client/main.css
@@ -1,4 +1,3 @@
-/* CSS declarations go here */
 #login-dropdown-list {
   position: relative;
 }

--- a/imports/ui/App.js
+++ b/imports/ui/App.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-apollo';
 import { Meteor } from 'meteor/meteor';
 import { createContainer } from 'meteor/react-meteor-data';
-import { Accounts } from 'meteor/std:accounts-ui';
+import { LoginButtons } from 'meteor/okgrow:accounts-ui-react';
 import gql from 'graphql-tag';
 
 Accounts.ui.config({
@@ -12,7 +12,7 @@ Accounts.ui.config({
 const App = ({ userId, currentUser }) => {
   return (
     <div>
-      <Accounts.ui.LoginForm />
+      <LoginButtons visible="true" />
       { userId ? (
         <div>
           <pre>{JSON.stringify(currentUser, null, 2)}</pre>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "apollo-client": "^0.3.29",
     "apollo-server": "^0.1.5",
+    "classnames": "^2.2.5",
     "express": "^4.14.0",
     "graphql": "^0.6.1",
     "graphql-tag": "^0.1.9",
@@ -16,6 +17,7 @@
     "react-addons-pure-render-mixin": "^15.0.1",
     "react-apollo": "^0.3.0",
     "react-dom": "^15.0.1",
+    "react-komposer": "^1.13.1",
     "tracker-component": "^1.3.16"
   }
 }


### PR DESCRIPTION
Let's move from std:accounts-ui to okgrow:accounts-ui-react. The okgrow package is just the blaze accounts-ui wrapped with blazetoreact. It has fewer moving parts and should be more robust, as well as being actively maintained.

This will remove problems with the accounts ui not rendering, having inactive buttons, etc. (see #16). Also, it will allow us to use the newest version of React, and to update to Meteor 1.4 (which also fails if you have std:accounts-ui installed).